### PR TITLE
Update vamas.py for floating coordinate in MAP file

### DIFF
--- a/vamas/vamas.py
+++ b/vamas/vamas.py
@@ -159,8 +159,8 @@ def _read_vamas(f: TextIO) -> tuple[VamasHeader, List[VamasBlock]]:
         b["technique"] = next(f).strip() if include[8] else fb["technique"]
 
         if h["experiment_mode"] in ["MAP", "MAPD"]:
-            b["x_coord"] = int(next(f)) if include[9] else fb["x_coord"]
-            b["y_coord"] = int(next(f)) if include[9] else fb["y_coord"]
+            b["x_coord"] = int(float(next(f))) if include[9] else fb["x_coord"]
+            b["y_coord"] = int(float(next(f))) if include[9] else fb["y_coord"]
 
         if include[10]:
             b["values_exp_var"] = []


### PR DESCRIPTION
Some MAP VAMAS file in XPS give coordinate in a floating format (example: -2.156)  when you read the file you get a string like '-2.156\n' which cause a fault when using int() I propose to use int(float('-2.156\n')) to get the int value of the coordinate